### PR TITLE
feat: Optimize cutter path with boustrophedon layout

### DIFF
--- a/Corel Layouts.gms
+++ b/Corel Layouts.gms
@@ -73,15 +73,22 @@ Sub CreateStickerLayout()
 
         ' Create a duplicate of the first shape
         Set duplicateShape = baseShape.Duplicate
-        duplicateShape.SetPosition startX + colCounter * (stickerWidth + spacingX), _
-                                   startY - rowCounter * (stickerHeight + spacingY)
+
+        ' Check if the current row is even or odd for boustrophedon layout
+        If (rowCounter Mod 2) = 0 Then
+            ' Even row: left-to-right
+            duplicateShape.SetPosition startX + colCounter * (stickerWidth + spacingX), _
+                                       startY - rowCounter * (stickerHeight + spacingY)
+        Else
+            ' Odd row: right-to-left
+            duplicateShape.SetPosition startX + (stickersPerRow - 1 - colCounter) * (stickerWidth + spacingX), _
+                                       startY - rowCounter * (stickerHeight + spacingY)
+        End If
 
         ' Update column counter and sticker count
         colCounter = colCounter + 1
         stickerCount = stickerCount + 1
     Loop
 
-    MsgBox "Stickers created successfully in a grid layout!", vbInformation, "Success"
+    MsgBox "Stickers created successfully in a boustrophedon layout!", vbInformation, "Success"
 End Sub
-
-


### PR DESCRIPTION
The original script created stickers in a simple grid layout (left-to-right, top-to-bottom). This resulted in inefficient cutter travel, with long movements from the end of one row to the start of the next.

This change modifies the sticker creation logic to use a boustrophedon (snake-like) pattern. Stickers are now created left-to-right on even rows and right-to-left on odd rows. This minimizes the travel distance for the cutter between rows, leading to faster and more efficient cutting operations.

The core change is within the main loop, which now checks the row number and adjusts the sticker's X-position accordingly.